### PR TITLE
Allow bytestring-0.11

### DIFF
--- a/tree-diff.cabal
+++ b/tree-diff.cabal
@@ -84,7 +84,7 @@ library
   -- GHC boot libraries
   build-depends:
     , base        >=4.5      && <4.16
-    , bytestring  ^>=0.9.2.1 || ^>=0.10.0.2
+    , bytestring  ^>=0.9.2.1 || ^>=0.10.0.2 || ^>=0.11.0.0
     , containers  ^>=0.4.2.1 || ^>=0.5.0.0 || ^>=0.6.0.1
     , parsec      ^>=3.1.13.0
     , pretty      ^>=1.1.1.0


### PR DESCRIPTION
Tested with 
```cabal
packages: .
tests: True

package tree-diff
  ghc-options: -Wall

constraints: bytestring >= 0.11

allow-newer:
  -- both merged, waiting for a revision
  blaze-markup:bytestring,
  blaze-html:bytestring
```