### PR TITLE
Depends on bytestring-builder on GHC < 7.8 only

### DIFF
--- a/tree-diff.cabal
+++ b/tree-diff.cabal
@@ -99,7 +99,6 @@ library
     , ansi-terminal         >=0.10       && <0.12
     , ansi-wl-pprint        ^>=0.6.8.2
     , base-compat           >=0.10.5     && <0.11 || >=0.11.0 && <0.13
-    , bytestring-builder    ^>=0.10.8.2.0
     , hashable              ^>=1.2.7.0 || ^>=1.3.0.0 || ^>=1.4.0.1
     , parsers               ^>=0.12.10
     , primitive             ^>=0.7.1.0
@@ -120,7 +119,9 @@ library
     build-depends: semigroups >=0.19.1 && <0.21
 
   if !impl(ghc >=7.8)
-    build-depends: generic-deriving >=1.13.1 && <1.15
+    build-depends:
+      , bytestring-builder ^>=0.10.8.2.0
+      , generic-deriving   >=1.13.1 && <1.15
 
   if !impl(ghc >=7.10)
     build-depends:


### PR DESCRIPTION
It's not needed on newer GHC.