### PR TITLE
Relax upper bound to accommodate dependency on `ansi-terminal-1.0`

### DIFF
--- a/tree-diff.cabal
+++ b/tree-diff.cabal
@@ -97,7 +97,7 @@ library
 
   build-depends:
     , aeson                 ^>=1.4.6.0    || ^>=1.5.6.0  || ^>=2.0.0.0 || ^>=2.1.0.0
-    , ansi-terminal         >=0.10        && <0.12
+    , ansi-terminal         >=0.10        && <1.1
     , ansi-wl-pprint        ^>=0.6.8.2
     , base-compat           >=0           && <0.13       || ^>=0.13
     , bytestring-builder    ^>=0.10.8.2.0


### PR DESCRIPTION
`ansi-terminal-1.0` is released on Hackage.

See also https://github.com/commercialhaskell/stackage/issues/6976.

Tested by building with Stack >= 2.9.3 and modified `stack.yaml`:
~~~yaml
# resolver: lts-13.23
resolver: lts-20.21 # GHC 9.2.7
packages: [.]

extra-deps:
- ansi-terminal-1.0
- ansi-terminal-types-0.11.5

allow-newer: true
allow-newer-deps:
- ansi-wl-pprint
~~~