### PR TITLE
Allow ansi-wl-pprint-1.0.2

### DIFF
--- a/tree-diff.cabal
+++ b/tree-diff.cabal
@@ -1,7 +1,7 @@
 cabal-version:      2.2
 name:               tree-diff
 version:            0.3.0.1
-x-revision:         1
+x-revision:         2
 synopsis:           Diffing of (expression) trees.
 category:           Data, Testing
 description:
@@ -99,7 +99,7 @@ library
   build-depends:
     , aeson                 ^>=1.4.6.0    || ^>=1.5.6.0  || ^>=2.0.0.0 || ^>=2.1.0.0
     , ansi-terminal         >=0.10        && <0.12       || ^>=1.0
-    , ansi-wl-pprint        ^>=0.6.8.2
+    , ansi-wl-pprint        ^>=0.6.8.2    || ^>=1.0.2
     , base-compat           >=0           && <0.13       || ^>=0.13
     , bytestring-builder    ^>=0.10.8.2.0
     , hashable              ^>=1.2.7.0    || ^>=1.3.0.0  || ^>=1.4.0.1


### PR DESCRIPTION
Will merge after `optparse-applicative` has support, so tests can be run.