### PR TITLE
Use prettyprinter instead of ansi-wl-pprint

### DIFF
--- a/src/Data/TreeDiff/Class.hs
+++ b/src/Data/TreeDiff/Class.hs
@@ -109,7 +109,7 @@ import Data.These (These (..))
 -- primitive
 import qualified Data.Primitive as Prim
 
-#if MIN_VERSION_base(4,9,0)
+#if MIN_VERSION_base(4,17,0)
 import Data.Array.Byte (ByteArray (..))
 #endif
 
@@ -602,7 +602,7 @@ instance (ToExpr a, ToExpr b) => ToExpr (These a b) where
 instance ToExpr Prim.ByteArray where
     toExpr ba = App "Prim.byteArrayFromList" [toExpr (Prim.foldrByteArray (:) [] ba :: [Word8])]
 
-#if !MIN_VERSION_primitive(0,8,0) && MIN_VERSION_base(4,9,0)
+#if !MIN_VERSION_primitive(0,8,0) && MIN_VERSION_base(4,17,0)
 -- | @since 0.2.2
 instance ToExpr ByteArray where
     toExpr (ByteArray ba) = App "byteArrayFromList" [toExpr (Prim.foldrByteArray (:) [] (Prim.ByteArray ba) :: [Word8])]

--- a/src/Data/TreeDiff/List.hs
+++ b/src/Data/TreeDiff/List.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 -- | A list diff.
 module Data.TreeDiff.List (
@@ -6,7 +6,7 @@ module Data.TreeDiff.List (
     Edit (..),
 ) where
 
-import Control.DeepSeq (NFData (..))
+import Control.DeepSeq  (NFData (..))
 import Control.Monad.ST (ST, runST)
 
 import qualified Data.Primitive as P

--- a/src/Data/TreeDiff/OMap.hs
+++ b/src/Data/TreeDiff/OMap.hs
@@ -15,11 +15,11 @@ module Data.TreeDiff.OMap (
     elems,
 ) where
 
-import Data.List      (sortBy)
-import Data.Ord       (comparing)
-import Data.Semialign (Semialign (..))
-import Data.These     (These (..))
-import Control.DeepSeq  (NFData (..))
+import Control.DeepSeq (NFData (..))
+import Data.List       (sortBy)
+import Data.Ord        (comparing)
+import Data.Semialign  (Semialign (..))
+import Data.These      (These (..))
 
 #if MIN_VERSION_containers(0,5,0)
 import qualified Data.Map.Strict as Map

--- a/src/Data/TreeDiff/QuickCheck.hs
+++ b/src/Data/TreeDiff/QuickCheck.hs
@@ -10,5 +10,5 @@ import Test.QuickCheck     (Property, counterexample)
 -- | A variant of '===', which outputs a diff when values are inequal.
 ediffEq :: (Eq a, ToExpr a) => a -> a -> Property
 ediffEq x y = counterexample
-    (setSGRCode [Reset] ++ show (ansiWlEditExpr $ ediff x y))
+    (setSGRCode [Reset] ++ show (ansiEditExpr $ ediff x y))
     (x == y)

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -16,12 +16,12 @@ import Test.Tasty.QuickCheck      (testProperty)
 import Data.Array.Byte (ByteArray (..))
 #endif
 
-import qualified Data.HashSet                 as HS
-import qualified Data.Primitive               as Prim
-import qualified Text.Parsec                  as P
-import qualified Text.PrettyPrint.ANSI.Leijen as WL
-import qualified Text.Trifecta                as T (eof, parseString)
-import qualified Text.Trifecta.Result         as T (ErrInfo (..), Result (..))
+import qualified Data.HashSet         as HS
+import qualified Data.Primitive       as Prim
+import qualified Prettyprinter        as PP
+import qualified Text.Parsec          as P
+import qualified Text.Trifecta        as T (eof, parseString)
+import qualified Text.Trifecta.Result as T (ErrInfo (..), Result (..))
 
 import Data.TreeDiff
 import Data.TreeDiff.Golden
@@ -33,7 +33,7 @@ import qualified RefDiffBy
 main :: IO ()
 main = defaultMain $ testGroup "tests"
     [ testProperty "trifecta-pretty roundtrip" roundtripTrifectaPretty
-    , testProperty "parsec-ansi-wl-pprint roundtrip" roundtripParsecAnsiWl
+    , testProperty "parsec-ansi-wl-pprint roundtrip" roundtripParsecAnsi
     , testProperty "diffBy example1" $ diffByModel [7,1,6,0,0] [0,0,6,7,1,0,0]
     , testProperty "diffBy model" diffByModel
     , goldenTests
@@ -76,10 +76,10 @@ roundtripTrifectaPretty e = counterexample info $ ediffEq (Just e) res'
         T.Success e' -> Just e'
         T.Failure _  -> Nothing
 
-roundtripParsecAnsiWl :: Expr -> Property
-roundtripParsecAnsiWl e = counterexample info $ ediffEq (Just e) res'
+roundtripParsecAnsi :: Expr -> Property
+roundtripParsecAnsi e = counterexample info $ ediffEq (Just e) res'
   where
-    doc = show (WL.plain (ansiWlExpr e))
+    doc = show (PP.unAnnotate (ansiExpr e))
     res = P.parse (exprParser <* P.eof) "<memory>" doc
 
     info = case res of

--- a/tree-diff.cabal
+++ b/tree-diff.cabal
@@ -97,23 +97,24 @@ library
     , time        >=1.4       && <1.5        || >=1.5.0.1   && <1.6 || >=1.6.0.1 && <1.7 || >=1.8.0.2 && <1.9 || >=1.9.3 && <1.13
 
   build-depends:
-    , aeson                 ^>=1.4.6.0    || ^>=1.5.6.0  || ^>=2.0.0.0 || ^>=2.1.0.0
-    , ansi-terminal         >=0.10        && <0.12       || ^>=1.0
-    , ansi-wl-pprint        ^>=0.6.8.2    || ^>=1.0.2
-    , base-compat           >=0           && <0.13       || ^>=0.13
-    , bytestring-builder    ^>=0.10.8.2.0
-    , hashable              ^>=1.2.7.0    || ^>=1.3.0.0  || ^>=1.4.0.1
-    , parsers               ^>=0.12.10
-    , primitive             >=0.7.1.0     && <0.8        || ^>=0.8
-    , QuickCheck            ^>=2.14.2
-    , scientific            ^>=0.3.6.2
-    , semialign             >=1.2.0.1     && <1.3        || ^>=1.3
-    , strict                >=0.4.0.1     && <0.5        || ^>=0.5
-    , tagged                ^>=0.8.6
-    , these                 >=1.1.1.1     && <1.2        || ^>=1.2
-    , unordered-containers  ^>=0.2.8.0
-    , uuid-types            ^>=1.0.3
-    , vector                ^>=0.12.0.0   || ^>=0.13.0.0
+    , aeson                        ^>=1.4.6.0    || ^>=1.5.6.0  || ^>=2.0.0.0 || ^>=2.1.0.0
+    , ansi-terminal                >=0.10        && <0.12       || ^>=1.0
+    , base-compat                  >=0           && <0.13       || ^>=0.13
+    , bytestring-builder           ^>=0.10.8.2.0
+    , hashable                     ^>=1.2.7.0    || ^>=1.3.0.0  || ^>=1.4.0.1
+    , parsers                      ^>=0.12.10
+    , prettyprinter                ^>=1.7.1
+    , prettyprinter-ansi-terminal  ^>=1.1.3
+    , primitive                    >=0.7.1.0     && <0.8        || ^>=0.8
+    , QuickCheck                   ^>=2.14.2
+    , scientific                   ^>=0.3.6.2
+    , semialign                    >=1.2.0.1     && <1.3        || ^>=1.3
+    , strict                       >=0.4.0.1     && <0.5        || ^>=0.5
+    , tagged                       ^>=0.8.6
+    , these                        >=1.1.1.1     && <1.2        || ^>=1.2
+    , unordered-containers         ^>=0.2.8.0
+    , uuid-types                   ^>=1.0.3
+    , vector                       ^>=0.12.0.0   || ^>=0.13.0.0
 
   if impl(ghc <7.5)
     build-depends: ghc-prim
@@ -157,10 +158,11 @@ test-suite tree-diff-test
   -- dependencies from library
   build-depends:
     , ansi-terminal
-    , ansi-wl-pprint
     , base
     , base-compat
     , parsec
+    , prettyprinter
+    , prettyprinter-ansi-terminal
     , primitive
     , QuickCheck
     , tagged


### PR DESCRIPTION
I didn't do anything fancy, just "inlining" what I found in `prettyprinter-compat-ansi-wl-pprint`.