### PR TITLE
Fix ANSI colored output

### DIFF
--- a/src/Data/TreeDiff/Golden.hs
+++ b/src/Data/TreeDiff/Golden.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 -- | "Golden tests" using 'ediff' comparison.
 module Data.TreeDiff.Golden (
     ediffGolden,
@@ -8,10 +9,13 @@ import System.Console.ANSI (SGR (Reset), setSGRCode)
 import Text.Parsec         (eof, parse)
 import Text.Parsec.Text ()
 
-import qualified Data.ByteString              as BS
-import qualified Data.Text                    as T
-import qualified Data.Text.Encoding           as TE
-import qualified Text.PrettyPrint.ANSI.Leijen as WL
+import qualified Data.ByteString               as BS
+import qualified Data.Text                     as T
+import qualified Data.Text.Encoding            as TE
+import           Prettyprinter
+                 (LayoutOptions (LayoutOptions, layoutPageWidth),
+                 PageWidth (AvailablePerLine), layoutPretty, unAnnotate)
+import           Prettyprinter.Render.Terminal (renderStrict)
 
 -- | Make a golden tests.
 --
@@ -52,8 +56,6 @@ ediffGolden impl testName fp x = impl testName expect actual cmp wrt
     cmp a b
         | a == b    = return Nothing
         | otherwise = return $ Just $
-            setSGRCode [Reset] ++ showWL (ansiWlEditExprCompact $ ediff a b)
-    wrt expr = BS.writeFile fp $ TE.encodeUtf8 $ T.pack $ showWL (WL.plain (ansiWlExpr expr)) ++ "\n"
-
-showWL :: WL.Doc -> String
-showWL doc = WL.displayS (WL.renderSmart 0.4 80 doc) ""
+            setSGRCode [Reset] ++ T.unpack (render $ ansiWlEditExprCompact $ ediff a b)
+    wrt expr = BS.writeFile fp $ TE.encodeUtf8 $ render (unAnnotate (ansiWlExpr expr)) `T.append` "\n"
+    render = renderStrict . layoutPretty LayoutOptions {layoutPageWidth=AvailablePerLine 80 0.4}

--- a/src/Data/TreeDiff/QuickCheck.hs
+++ b/src/Data/TreeDiff/QuickCheck.hs
@@ -3,12 +3,18 @@ module Data.TreeDiff.QuickCheck (
     ediffEq,
     ) where
 
-import Data.TreeDiff
-import System.Console.ANSI (SGR (Reset), setSGRCode)
-import Test.QuickCheck     (Property, counterexample)
+import qualified Data.Text.Lazy                as TL
+import           Data.TreeDiff
+import           Prettyprinter
+                 (defaultLayoutOptions, layoutPretty)
+import           Prettyprinter.Render.Terminal (renderLazy)
+import           System.Console.ANSI           (SGR (Reset), setSGRCode)
+import           Test.QuickCheck               (Property, counterexample)
 
 -- | A variant of '===', which outputs a diff when values are inequal.
 ediffEq :: (Eq a, ToExpr a) => a -> a -> Property
 ediffEq x y = counterexample
-    (setSGRCode [Reset] ++ show (ansiWlEditExpr $ ediff x y))
+    (setSGRCode [Reset] ++ render (ansiWlEditExpr $ ediff x y))
     (x == y)
+    where
+        render = TL.unpack . renderLazy . layoutPretty defaultLayoutOptions

--- a/tree-diff.cabal
+++ b/tree-diff.cabal
@@ -91,21 +91,23 @@ library
     , time        ^>=1.8.0.2  || ^>=1.9.3    || ^>=1.10     || ^>=1.11 || ^>=1.12
 
   build-depends:
-    , aeson                 ^>=2.2.0.0
-    , ansi-terminal         ^>=1.1
-    , ansi-wl-pprint        ^>=1.0.2
-    , hashable              ^>=1.4.4.0  || ^>=1.5.0.0
-    , parsers               ^>=0.12.11
-    , primitive             ^>=0.9.0.0
-    , QuickCheck            ^>=2.14.2   || ^>=2.15
-    , scientific            ^>=0.3.8.0
-    , semialign             ^>=1.3.1
-    , strict                ^>=0.5
-    , tagged                ^>=0.8.8
-    , these                 ^>=1.2.1
-    , unordered-containers  ^>=0.2.20
-    , uuid-types            ^>=1.0.6
-    , vector                ^>=0.13.1.0
+    , aeson                               ^>=2.2.0.0
+    , ansi-terminal                       ^>=1.1
+    , prettyprinter                       ^>=1.7.1
+    , prettyprinter-ansi-terminal         ^>=1.1.3
+    , prettyprinter-compat-ansi-wl-pprint ^>=1.0.2
+    , hashable                            ^>=1.4.4.0  || ^>=1.5.0.0
+    , parsers                             ^>=0.12.11
+    , primitive                           ^>=0.9.0.0
+    , QuickCheck                          ^>=2.14.2   || ^>=2.15
+    , scientific                          ^>=0.3.8.0
+    , semialign                           ^>=1.3.1
+    , strict                              ^>=0.5
+    , tagged                              ^>=0.8.8
+    , these                               ^>=1.2.1
+    , unordered-containers                ^>=0.2.20
+    , uuid-types                          ^>=1.0.6
+    , vector                              ^>=0.13.1.0
 
   if (impl(ghc >=8) && !impl(ghc >=9.4))
     build-depends: data-array-byte ^>=0.1.0.1
@@ -134,7 +136,7 @@ test-suite tree-diff-test
   -- dependencies from library
   build-depends:
     , ansi-terminal
-    , ansi-wl-pprint
+    , prettyprinter-compat-ansi-wl-pprint
     , base
     , parsec
     , primitive


### PR DESCRIPTION
The [`ansi-wl-pprint` changelog for 1.0.2](https://github.com/ekmett/ansi-wl-pprint/blob/master/Changelog.md#102) says that "Using `show` won't preserve formatting anymore, as `prettyprinter`s `Show Doc` instance is annotation invariant."

This patch applies their suggested workaround, `Text.unpack . renderLazy . layoutPretty defaultLayoutOptions`.