### PR TITLE
Loosen dependency bounds

### DIFF
--- a/tree-diff.cabal
+++ b/tree-diff.cabal
@@ -91,20 +91,20 @@ library
     , time        ^>=1.8.0.2  || ^>=1.9.3    || ^>=1.10     || ^>=1.11 || ^>=1.12
 
   build-depends:
-    , aeson                 ^>=2.2.0.0
-    , ansi-terminal         ^>=1.1
+    , aeson                 >=2.1.2.1 && < 2.3
+    , ansi-terminal         >=1.0.2 && < 1.2
     , ansi-wl-pprint        ^>=1.0.2
     , hashable              ^>=1.4.4.0  || ^>=1.5.0.0
     , parsers               ^>=0.12.11
-    , primitive             ^>=0.9.0.0
+    , primitive             >=0.8.0.0 && < 0.10
     , QuickCheck            ^>=2.14.2   || ^>=2.15
-    , scientific            ^>=0.3.8.0
-    , semialign             ^>=1.3.1
+    , scientific            ^>=0.3.7.0
+    , semialign             ^>=1.3
     , strict                ^>=0.5
     , tagged                ^>=0.8.8
-    , these                 ^>=1.2.1
+    , these                 ^>=1.2
     , unordered-containers  ^>=0.2.20
-    , uuid-types            ^>=1.0.6
+    , uuid-types            >=1.0.5 && < 1.1
     , vector                ^>=0.13.1.0
 
   if (impl(ghc >=8) && !impl(ghc >=9.4))
@@ -151,9 +151,9 @@ test-suite tree-diff-test
 
   -- extra dependencies
   build-depends:
-    , tasty             ^>=1.5
+    , tasty             >=1.4 && < 1.6
     , tasty-golden      ^>=2.3.5
-    , tasty-quickcheck  ^>=0.10.3 || ^>=0.11
+    , tasty-quickcheck  ^>=0.10.2 || ^>=0.11
     , trifecta          ^>=2.1.4
 
 benchmark tree-diff-bench


### PR DESCRIPTION
This is mainly to work with the default package set from Nixpkgs. These looser bounds build just fine.